### PR TITLE
Implemented streaming for create_chat_completion

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ Description: An R wrapper of OpenAI API endpoints (see
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3
 URL: https://github.com/irudnyts/openai,
     https://irudnyts.github.io/openai/
 BugReports: https://github.com/irudnyts/openai/issues

--- a/R/create_chat_completion.R
+++ b/R/create_chat_completion.R
@@ -237,6 +237,14 @@ create_chat_completion<- function(
 
     verify_mime_type(response)
 
+    if (stream) {
+        return()
+    }
+
+    parsed <- response %>%
+        httr::content(as = "text", encoding = "UTF-8") %>%
+        jsonlite::fromJSON(flatten = TRUE)
+
     #---------------------------------------------------------------------------
     # Check whether request failed and return parsed
 
@@ -249,14 +257,6 @@ create_chat_completion<- function(
         ) %>%
             stop(call. = FALSE)
     }
-
-    if (stream) {
-        return(response)
-    }
-
-    parsed <- response %>%
-        httr::content(as = "text", encoding = "UTF-8") %>%
-        jsonlite::fromJSON(flatten = TRUE)
 
     parsed
 }

--- a/R/verify_mime_type.R
+++ b/R/verify_mime_type.R
@@ -1,6 +1,5 @@
 verify_mime_type <- function(result) {
-
-    if (httr::http_type(result) != "application/json") {
+    if (!httr::http_type(result) %in% c("application/json", "text/event-stream")) {
         paste(
             "OpenAI API probably has been changed. If you see this, please",
             "rise an issue at: https://github.com/irudnyts/openai/issues"

--- a/examples/streaming_chat_shiny.R
+++ b/examples/streaming_chat_shiny.R
@@ -21,6 +21,7 @@ stream_parser <- function(x) {
 }
 
 ui <- fluidPage(
+    selectInput(inputId = "model", label = "Select model", choices = c("gpt-4", "gpt-3.5-turbo")),
     textAreaInput(inputId = "prompt", label = "Enter your prompt here", value = "Count to 100"),
     actionButton(inputId = "send", label = "Send"),
     textOutput(outputId = "answer")
@@ -31,9 +32,10 @@ server <- function(input, output, session) {
     observeEvent(input$send, {
         saveRDS(character(), temp_stream_content)
         prompt <- input$prompt
+        model <- input$model
         future_promise({
             create_chat_completion(
-                model = "gpt-3.5-turbo",
+                model = model,
                 messages = list(
                     list(
                         "role" = "system",

--- a/examples/streaming_chat_shiny.R
+++ b/examples/streaming_chat_shiny.R
@@ -1,0 +1,72 @@
+library(openai)
+library(shiny)
+library(promises)
+library(future)
+plan(multisession)
+
+temp_stream_content <- tempfile(fileext = ".rds")
+temp_finished <- tempfile(fileext = ".rds")
+
+stream_parser <- function(x) {
+    stream_content <- character()
+    finished <- FALSE
+    for (i in seq_along(x)) {
+        stream_content <- paste0(stream_content, x[[i]]$choices$delta.content)
+        finished <- !is.na(x[[i]]$choices$finish_reason)
+    }
+    list(
+        stream_content = stream_content,
+        finished = finished
+    )
+}
+
+ui <- fluidPage(
+    textAreaInput(inputId = "prompt", label = "Enter your prompt here", value = "Count to 100"),
+    actionButton(inputId = "send", label = "Send"),
+    textOutput(outputId = "answer")
+)
+
+server <- function(input, output, session) {
+    finished <- reactiveVal(TRUE)
+    observeEvent(input$send, {
+        saveRDS(character(), temp_stream_content)
+        finished(FALSE)
+        saveRDS(finished(), temp_finished)
+        prompt <- input$prompt
+        future_promise({
+            create_chat_completion(
+                model = "gpt-3.5-turbo",
+                messages = list(
+                    list(
+                        "role" = "system",
+                        "content" = "You are a helpful assistant."
+                    ),
+                    list(
+                        "role" = "user",
+                        "content" = prompt
+                    )
+                ),
+                stream = TRUE,
+                stream_function = function(x) {
+                    rds_content <- readRDS(temp_stream_content)
+                    stream <- stream_parser(x)
+                    stream_content <- paste0(rds_content, stream$stream_content)
+                    saveRDS(stream_content, temp_stream_content)
+                    saveRDS(stream$finished, temp_finished)
+                }
+            )
+        })
+        return()
+    })
+    output$answer <- renderText({
+        if (input$send > 0 && !finished()) {
+            invalidateLater(250)
+        }
+        if (file.exists(temp_stream_content)) {
+            finished(readRDS(temp_finished))
+            readRDS(temp_stream_content)
+        }
+    })
+}
+
+shinyApp(ui, server)

--- a/examples/streaming_chat_shiny.R
+++ b/examples/streaming_chat_shiny.R
@@ -30,8 +30,6 @@ server <- function(input, output, session) {
     finished <- reactiveVal(TRUE)
     observeEvent(input$send, {
         saveRDS(character(), temp_stream_content)
-        finished(FALSE)
-        saveRDS(finished(), temp_finished)
         prompt <- input$prompt
         future_promise({
             create_chat_completion(
@@ -56,7 +54,8 @@ server <- function(input, output, session) {
                 }
             )
         })
-        return()
+        finished(FALSE)
+        saveRDS(finished(), temp_finished)
     })
     output$answer <- renderText({
         if (input$send > 0 && !finished()) {

--- a/man/create_chat_completion.Rd
+++ b/man/create_chat_completion.Rd
@@ -11,6 +11,7 @@ create_chat_completion(
   top_p = 1,
   n = 1,
   stream = FALSE,
+  stream_function = function(x) print(x),
   stop = NULL,
   max_tokens = NULL,
   presence_penalty = 0,
@@ -36,8 +37,10 @@ value between \code{0} and \code{1}.}
 \item{n}{required; defaults to \code{1}; a length one numeric vector with the
 integer value greater than \code{0}.}
 
-\item{stream}{required; defaults to \code{FALSE}; a length one logical vector.
-\strong{Currently is not implemented.}}
+\item{stream}{required; defaults to \code{FALSE}; a length one logical vector.}
+
+\item{stream_function}{only required if \code{stream} is \code{TRUE}. Specifies the callback function
+that will be applied to each chunk of the response. Default function just prints the chunks.}
 
 \item{stop}{optional; defaults to \code{NULL}; a character vector of length
 between one and four.}

--- a/tests/testthat/helper-test_argument_validation.R
+++ b/tests/testthat/helper-test_argument_validation.R
@@ -1,7 +1,7 @@
 test_argument_validation <- function(
         function_name,
         argument_name,
-        argument_type = c("character", "string", "number", "count", "flag"),
+        argument_type = c("character", "string", "number", "count", "flag", "function"),
         allow_null = FALSE,
         suppress_warnings = FALSE
 ) {
@@ -18,6 +18,8 @@ test_argument_validation <- function(
         non_valid_values <- list(NA_character_, -10, 0.5, NA_integer_)
     } else if (argument_type == "flag") {
         non_valid_values <- list(NA, NA_integer_, 32, "TRUE")
+    } else if (argument_type == "function") {
+        non_valid_values <- list(NA, NA_character_, NA_integer_, TRUE, 32, -10, 0.5, "one")
     }
 
     if (!allow_null) {

--- a/tests/testthat/test-create_chat_completion.R
+++ b/tests/testthat/test-create_chat_completion.R
@@ -40,6 +40,13 @@ test_argument_validation(
 
 test_argument_validation(
     function_name = function_name,
+    argument_name = "stream_function",
+    argument_type = "function",
+    allow_null = FALSE
+)
+
+test_argument_validation(
+    function_name = function_name,
     argument_name = "stop",
     argument_type = "character",
     allow_null = TRUE

--- a/tests/testthat/test-create_chat_completion.R
+++ b/tests/testthat/test-create_chat_completion.R
@@ -42,7 +42,7 @@ test_argument_validation(
     function_name = function_name,
     argument_name = "stream_function",
     argument_type = "function",
-    allow_null = FALSE
+    allow_null = TRUE
 )
 
 test_argument_validation(


### PR DESCRIPTION
Closes #48

This PR introduces the implementation of streaming for `create_chat_completion` and also adds an example of how to use it in a Shiny application. It can be implemented similarly for all endpoints with a `stream` argument. 

Also, I am not sure if we should or the best way to parse the response before applying the `stream_function`. So I am open to suggestions :)